### PR TITLE
Got restrict-maven-plugin working with java 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
-.idea/
+#maven
 target/
+
+#idea
+.idea/
 restrict-maven-plugin.iml
 
+#eclipse
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,16 @@
         </developer>
     </developers>
 
+    <contributors>
+        <contributor>
+            <name>Marvin Froeder</name>
+            <email>velo dot br at gmail dot com</email>
+            <roles>
+                <role>Java 8 support</role>
+            </roles>
+        </contributor>
+    </contributors>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -72,9 +82,9 @@
             <version>3.0.8</version>
         </dependency>
         <dependency>
-            <groupId>javassist</groupId>
+            <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
-            <version>3.3.GA</version>
+            <version>3.18.2-GA</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
While running restrict-maven-plugin against a java8 project got the following error:
```
[ERROR] Failed to execute goal com.yamanyar:restrict-maven-plugin:0.6:restrict (default) on project invoice-issuer-business: Can not inspect all the artifacts: invalid constant type: 18 -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.yamanyar:restrict-maven-plugin:0.6:restrict (default) on project invoice-issuer-business: Can not inspect all the artifacts
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:216)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:108)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:76)
        at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:116)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:361)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:155)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:584)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:213)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:157)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:483)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoExecutionException: Can not inspect all the artifacts
        at com.yamanyar.mvn.plugin.RestrictMojo.execute(RestrictMojo.java:87)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:133)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
        ... 19 more
Caused by: java.io.IOException: invalid constant type: 18
        at javassist.bytecode.ConstPool.readOne(ConstPool.java:967)
        at javassist.bytecode.ConstPool.read(ConstPool.java:910)
        at javassist.bytecode.ConstPool.<init>(ConstPool.java:127)
        at javassist.bytecode.ClassFile.read(ClassFile.java:625)
        at javassist.bytecode.ClassFile.<init>(ClassFile.java:52)
        at javassist.CtClassType.<init>(CtClassType.java:95)
        at javassist.ClassPool.makeClass(ClassPool.java:588)
        at com.yamanyar.mvn.plugin.inspectors.Inspector.inspectClass(Inspector.java:105)
        at com.yamanyar.mvn.plugin.inspectors.Inspector.inspectClassFile(Inspector.java:218)
        at com.yamanyar.mvn.plugin.inspectors.Inspector.inspectFolder(Inspector.java:227)
        at com.yamanyar.mvn.plugin.RestrictMojo.execute(RestrictMojo.java:84)
        ... 21 more
```

I did not created any tests since it would demand restrict-maven-plugin to be built using java 8 =/