### PR TITLE
JDK8 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
-.idea/
+#maven
 target/
+
+#idea
+.idea/
 restrict-maven-plugin.iml
 
+#eclipse
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,16 @@
         </developer>
     </developers>
 
+    <contributors>
+        <contributor>
+            <name>Marvin Froeder</name>
+            <email>velo dot br at gmail dot com</email>
+            <roles>
+                <role>Java 8 support</role>
+            </roles>
+        </contributor>
+    </contributors>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -72,9 +82,9 @@
             <version>3.0.8</version>
         </dependency>
         <dependency>
-            <groupId>javassist</groupId>
+            <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
-            <version>3.3.GA</version>
+            <version>3.18.2-GA</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/yamanyar/mvn/plugin/inspectors/Inspector.java
+++ b/src/main/java/com/yamanyar/mvn/plugin/inspectors/Inspector.java
@@ -134,7 +134,7 @@ public class Inspector {
                                         MethodInfo minfo = declaredMethod.getMethodInfo();
                                         minfo.getCodeAttribute();
                                         CodeAttribute ca = minfo.getCodeAttribute();
-                                        for (CodeIterator ci = ca.iterator(); ci.hasNext(); ) {
+                                        if(null!=ca) for (CodeIterator ci = ca.iterator(); ci.hasNext(); ) {
                                             int index = 0;
                                             try {
                                                 index = ci.next();

--- a/src/main/java/com/yamanyar/mvn/plugin/inspectors/Inspector.java
+++ b/src/main/java/com/yamanyar/mvn/plugin/inspectors/Inspector.java
@@ -152,8 +152,12 @@ public class Inspector {
                                                     case Opcode.INVOKEVIRTUAL:
                                                     case Opcode.INVOKESPECIAL:
                                                     case Opcode.INVOKESTATIC:
-                                                        desc = constPool.getMethodrefClassName(theIndex) + "." + constPool.getMethodrefName(theIndex) + "()";
-                                                        break;
+                                                        // As of JDK8, interfaces can have static methods! So if this is not a methodref,
+                                                        // try falling through to the INVOKEINTERFACE case, as it might just be an interfacemethodref
+                                                        if(constPool.getTag(theIndex) == ConstPool.CONST_Methodref) {
+                                                            desc = constPool.getMethodrefClassName(theIndex) + "." + constPool.getMethodrefName(theIndex) + "()";
+                                                            break;
+                                                        }
                                                     case Opcode.INVOKEINTERFACE:
                                                         desc = constPool.getInterfaceMethodrefClassName(theIndex) + "." + constPool.getInterfaceMethodrefName(theIndex) + "()";
 


### PR DESCRIPTION
This happens to include velo's PR (see velo's PR) which updates the javassist version, and I also added a change to work correctly with JDK8 static interface methods, as well as a (possibly questionable...) null check to not descend into inspecting bytecode of abstract methods.